### PR TITLE
Fix NaN crash

### DIFF
--- a/Pod/Classes/Label/YALLabel.m
+++ b/Pod/Classes/Label/YALLabel.m
@@ -89,10 +89,12 @@
                                                  [self.fillLayer removeFromSuperlayer];
                                              }];
         CGRect frame = CGPathGetPathBoundingBox(self.fillLayer.path);
-        self.fillLayer.position = (CGPoint){
-            (CGRectGetWidth(self.frame) - CGRectGetWidth(frame)) / 2.f,
-            (CGRectGetHeight(self.frame) - CGRectGetHeight(frame)) / 2.f
-        };
+        if (!isnan(CGRectGetWidth(frame))) {
+            self.fillLayer.position = (CGPoint){
+                (CGRectGetWidth(self.frame) - CGRectGetWidth(frame)) / 2.f,
+                (CGRectGetHeight(self.frame) - CGRectGetHeight(frame)) / 2.f
+            };
+        }
     }
 }
 
@@ -108,10 +110,12 @@
                                                }];
         CGRect frame = CGPathGetPathBoundingBox(self.strokeLayer.path);
         frame = CGRectInset(frame, self.strokeWidth, self.strokeWidth);
-        self.strokeLayer.position = (CGPoint){
-            (CGRectGetWidth(self.frame) - CGRectGetWidth(frame)) / 2.f,
-            (CGRectGetHeight(self.frame) - CGRectGetHeight(frame)) / 2.f
-        };
+        if (!isnan(CGRectGetWidth(frame))) {
+            self.strokeLayer.position = (CGPoint){
+                (CGRectGetWidth(self.frame) - CGRectGetWidth(frame)) / 2.f,
+                (CGRectGetHeight(self.frame) - CGRectGetHeight(frame)) / 2.f
+            };
+        }
     }
 }
 


### PR DESCRIPTION
The example crashes because iOS now checks the CALayer position doesn't contain NaN values. This PR checks for NaN before assigning to the layer position.